### PR TITLE
feat(auth): move missing username and password handling to go

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,17 @@ including cached ones, will drop Mosquitto's passed `username` and use `clientid
 
 This option default to false if not given or anything but `true` is set to its value.
 
+#### Allow empty passwords
+
+By default the plugin rejects authentication attempts that present an empty password. You can override this behavior with:
+
+```
+auth_opt_allow_empty_credentials true
+```
+
+When set to `true`, empty username and passwords will be allowed. When omitted or set to any value other than `true`, the plugin will reject empty usernames or passwords (default behavior). This option is useful when some backends or clients deliberately send an empty password and you want to permit it.
+
+
 #### Cache
 
 There are 2 types of caches supported: an in memory one using [go-cache](https://github.com/patrickmn/go-cache), or a Redis backed one.

--- a/auth-plugin.c
+++ b/auth-plugin.c
@@ -84,10 +84,12 @@ int mosquitto_auth_unpwd_check(void *userdata, const char *username, const char 
   #else
     const char* clientid = "";
   #endif
-  if (username == NULL || password == NULL) {
-    printf("error: received null username or password for unpwd check\n");
-    fflush(stdout);
-    return MOSQ_ERR_AUTH;
+
+  if (username == NULL) {
+    username = "";
+  }
+  if (password == NULL) {
+    password = "";
   }
 
   GoUint8 ret = AuthUnpwdCheck((char *)username, (char *)password, (char *)clientid);

--- a/go-auth.go
+++ b/go-auth.go
@@ -4,6 +4,7 @@ import "C"
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -15,8 +16,15 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// BackendsChecker is the interface used by AuthPlugin to check credentials and ACLs.
+type BackendsChecker interface {
+	AuthUnpwdCheck(username, password, clientid string) (bool, error)
+	AuthAclCheck(clientid, username, topic string, acc int) (bool, error)
+	Halt()
+}
+
 type AuthPlugin struct {
-	backends              *bes.Backends
+	backends              BackendsChecker
 	useCache              bool
 	logLevel              log.Level
 	logDest               string
@@ -326,7 +334,7 @@ func authUnpwdCheck(username, password, clientid string) (bool, error) {
 	// Enforce empty-password policy in Go: if password is empty and not allowed, reject.
 	if (password == "" || username == "") && !authPlugin.allowEmptyCredentials {
 		log.Debugf("empty username or password not allowed")
-		return false, nil
+		return false, fmt.Errorf("empty username or password not allowed")
 	}
 
 	if authPlugin.useCache {

--- a/go-auth.go
+++ b/go-auth.go
@@ -26,6 +26,7 @@ type AuthPlugin struct {
 	hasher                hashing.HashComparer
 	retryCount            int
 	useClientidAsUsername bool
+	allowEmptyCredentials bool
 }
 
 // errors to signal mosquitto
@@ -64,11 +65,18 @@ func AuthPluginInit(keys []*C.char, values []*C.char, authOptsNum int, version *
 		}
 	}
 
-	if useClientidAsUsername, ok := authOpts["use_clientid_as_username"]; ok && strings.Replace(useClientidAsUsername, " ", "", -1) == "true" {
+	if useClientidAsUsername, ok := authOpts["use_clientid_as_username"]; ok && strings.ReplaceAll(useClientidAsUsername, " ", "") == "true" {
 		log.Info("clientid will be used as username on checks")
 		authPlugin.useClientidAsUsername = true
 	} else {
 		authPlugin.useClientidAsUsername = false
+	}
+
+	if allowEmptyCredentials, ok := authOpts["allow_empty_credentials"]; ok && strings.ReplaceAll(allowEmptyCredentials, " ", "") == "true" {
+		log.Info("empty credentials will be allowed")
+		authPlugin.allowEmptyCredentials = true
+	} else {
+		authPlugin.allowEmptyCredentials = false
 	}
 
 	//Check if log level is given. Set level if any valid option is given.
@@ -314,6 +322,12 @@ func authUnpwdCheck(username, password, clientid string) (bool, error) {
 	var err error
 
 	username = setUsername(username, clientid)
+
+	// Enforce empty-password policy in Go: if password is empty and not allowed, reject.
+	if (password == "" || username == "") && !authPlugin.allowEmptyCredentials {
+		log.Debugf("empty username or password not allowed")
+		return false, nil
+	}
 
 	if authPlugin.useCache {
 		log.Debugf("checking auth cache for %s", username)

--- a/go-auth_test.go
+++ b/go-auth_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+type mockBackends struct {
+	authResult bool
+	authErr    error
+}
+
+func (m *mockBackends) AuthUnpwdCheck(username, password, clientid string) (bool, error) {
+	return m.authResult, m.authErr
+}
+
+func (m *mockBackends) AuthAclCheck(clientid, username, topic string, acc int) (bool, error) {
+	return false, nil
+}
+
+func (m *mockBackends) Halt() {}
+
+var errBackendFailure = errors.New("simulated backend failure")
+
+func Test_authUnpwdCheck(t *testing.T) {
+	testCases := []struct {
+		name         string
+		username     string
+		password     string
+		emptyEnabled bool
+		wantOK       bool
+		wantErr      bool
+		backendErr   error
+		backendOk    bool
+	}{
+		{
+			name:         "Missing username",
+			username:     "",
+			password:     "pass1",
+			emptyEnabled: false,
+			wantOK:       false,
+			wantErr:      true,
+			backendErr:   nil,
+			backendOk:    true,
+		},
+		{
+			name:         "Missing password",
+			username:     "user1",
+			password:     "",
+			emptyEnabled: false,
+			wantOK:       false,
+			wantErr:      true,
+			backendErr:   nil,
+			backendOk:    true,
+		},
+		{
+			name:         "Empty credentials allowed: only username",
+			username:     "valid-username",
+			password:     "",
+			emptyEnabled: true,
+			wantOK:       true,
+			wantErr:      false,
+			backendErr:   nil,
+			backendOk:    true,
+		},
+		{
+			name:         "Empty credentials allowed: only password",
+			username:     "",
+			password:     "valid-password",
+			emptyEnabled: true,
+			wantOK:       true,
+			wantErr:      false,
+			backendErr:   nil,
+			backendOk:    true,
+		},
+		{
+			name:         "Empty credentials allowed: both empty",
+			username:     "",
+			password:     "",
+			emptyEnabled: true,
+			wantOK:       true,
+			wantErr:      false,
+			backendErr:   nil,
+			backendOk:    true,
+		},
+		{
+			name:         "Backend error",
+			username:     "user1",
+			password:     "pass1",
+			emptyEnabled: false,
+			wantOK:       false,
+			wantErr:      true,
+			backendErr:   errBackendFailure, // Simulate a backend error
+			backendOk:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			authPlugin = AuthPlugin{
+				backends:              &mockBackends{authResult: tc.backendOk, authErr: tc.backendErr},
+				allowEmptyCredentials: tc.emptyEnabled,
+			}
+
+			ok, err := authUnpwdCheck(tc.username, tc.password, "client-id")
+
+			if ok != tc.wantOK {
+				t.Errorf("Expected ok to be %v, got %v", tc.wantOK, ok)
+			}
+
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Expected error presence to be %v, got %v", tc.wantErr, err != nil)
+			}
+		})
+	}
+}

--- a/mosquitto_stubs.go
+++ b/mosquitto_stubs.go
@@ -1,0 +1,10 @@
+package main
+
+/*
+// Weak stubs for mosquitto symbols.
+// During normal plugin use these are overridden by the broker's real implementations.
+// During `go test` they satisfy the linker so a test binary can be built.
+__attribute__((weak)) const char* mosquitto_client_id(const void *client) { (void)client; return ""; }
+__attribute__((weak)) const char* mosquitto_client_username(const void *client) { (void)client; return ""; }
+*/
+import "C"


### PR DESCRIPTION
Handle NULL password or username in C adapter and enforce policy in Go plugin

If no username or password were sent by the client the c adapter aborted the authentication before it would reach any authenticator backends.

The actual issue I'm solving is that we use a different mqtt server. We use JWT authentication and some clients are sending the JWT token in the username field but they don't send any password. I needed to allow missing password field, but then I think it's better to set username and password value to go's zero value and let the authentication backends to handle it.

I also added a flag, so the original behavior won't change.