### PR TITLE
fix(hashing): replace every \$ byte in PBKDF2 salt, not just the first

### DIFF
--- a/hashing/pbkdf2.go
+++ b/hashing/pbkdf2.go
@@ -46,18 +46,17 @@ func (h pbkdf2Hasher) Hash(password string) (string, error) {
 	salt := make([]byte, h.saltSize)
 	_, err := rand.Read(salt)
 
-	// We need to ensure that salt doesn't contain $, which is 36 in decimal.
-	// So we check if there's byte that represents $ and change it with a random number in the range 0-35
-	// // This is far from ideal, but should be good enough with a reasonable salt size.
+	// We need to ensure that salt doesn't contain $, which is 36 in decimal,
+	// because $ is used as the field separator in the stored hash string.
+	// Replace every $ byte with a random byte in 0-34. This is far from ideal,
+	// but should be good enough with a reasonable salt size.
 	for i := 0; i < len(salt); i++ {
 		if salt[i] == 36 {
 			n, err := rand.Int(rand.Reader, big.NewInt(35))
 			if err != nil {
 				return "", fmt.Errorf("read random byte error: %s", err)
 			}
-
 			salt[i] = byte(n.Int64())
-			break
 		}
 	}
 	if err != nil {


### PR DESCRIPTION
## Symptom

The \`Test with Mosquitto version 1.x\` CI job (and occasionally the 2.x matrix entry) intermittently fails with:

    === RUN   TestPBKDF2/OlderFormat/UTF8
    level=error msg="base64 hash decoding error: illegal base64 data at input byte 0"
        hashing_test.go:144:
                Error:          Should be true
                Test:           TestPBKDF2/OlderFormat/UTF8

Most CI runs pass; retries usually succeed. No code change around the failure, and the same subtest on the Base64 salt-encoding variant always passes, which made it look like a flake.

## Cause

The PBKDF2 hasher stores hashes as \`PBKDF2\$<alg>\$<iter>\$<salt>\$<hash>\`, using \`\$\` (byte value 36) as the field separator. With UTF8 salt encoding the salt is written as raw bytes, so any random byte that happens to equal \`\$\` becomes an extra separator.

\`hashing/pbkdf2.go\` had code meant to avoid this by re-rolling any \`\$\` byte in the salt:

    for i := 0; i < len(salt); i++ {
        if salt[i] == 36 {
            n, _ := rand.Int(rand.Reader, big.NewInt(35))
            salt[i] = byte(n.Int64())
            break        // <-- bug: only the first \$ gets replaced
        }
    }

The \`break\` meant only the FIRST \`\$\` byte was rewritten. With a 16-byte salt, P(exactly 1 \$) is around 6%, but P(two or more \$) is around 0.18%. When a salt had two-or-more \$ bytes, \`Compare\` split the stored string into 6+ fields instead of 5; \`hashSplit[4]\` — expected to be the base64-encoded hash — was instead bytes from the middle of the salt, which almost never form valid base64 and so fail with "illegal base64 data at input byte 0". That failure is what the CI hit.

## Fix

Drop the \`break\` so every \`\$\` byte in the salt gets rewritten. The loop cost is trivial and the UTF8-encoded format becomes unambiguous again. Verified by running \`go test ./hashing -run TestPBKDF2 -count=100\` locally without a failure.