### PR TITLE
fix: do not replace username and password

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,12 @@ without-vcs:
 test:
 	cd plugin && make
 	go test ./backends ./cache ./hashing -v -count=1 -buildvcs=false
+	go test . -v -count=1 -buildvcs=false -tags test
 	rm plugin/*.so
+
+test-main:
+	cd plugin && make
+	go test . -v -count=1 -buildvcs=false -tags test
 
 test-backends:
 	cd plugin && make

--- a/mosquitto_stubs.go
+++ b/mosquitto_stubs.go
@@ -1,3 +1,6 @@
+//go:build test
+// +build test
+
 package main
 
 /*


### PR DESCRIPTION
The test stub replaced the username and password with empty string, so improve the test setup by using build tags

Add a test build tag to mosquitto_stubs.go so the file is only included
when running tests that require the mosquitto stubs.

Update Makefile test target to run package-level tests with the test build tag, and add a new test-main target that runs only the package tests with -tags test. Plugin and backend test targets remain unchanged.
