### PR TITLE
Potential fix for code scanning alert no. 3: Incorrect conversion between integer types

### DIFF
--- a/go-auth.go
+++ b/go-auth.go
@@ -78,9 +78,9 @@ func AuthPluginInit(keys []*C.char, values []*C.char, authOptsNum int, version *
 	}
 
 	if retryCount, ok := authOpts["retry_count"]; ok {
-		retry, err := strconv.ParseInt(retryCount, 10, 64)
+		retry, err := strconv.Atoi(retryCount)
 		if err == nil {
-			authPlugin.retryCount = int(retry)
+			authPlugin.retryCount = retry
 		} else {
 			log.Warningf("couldn't parse retryCount (err: %s), defaulting to 0", err)
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/lhns/mosquitto-go-auth/security/code-scanning/3](https://github.com/lhns/mosquitto-go-auth/security/code-scanning/3)

General fix: avoid parsing into a wider integer type than needed for the destination type, or add explicit constant bound checks before conversion.

Best fix here (minimal functional change): parse `retry_count` directly as `int` width by using `strconv.Atoi`, which returns `int` and avoids the problematic narrowing conversion. Keep existing behavior (default to `0` when parse fails) and existing logging.

Change needed in **go-auth.go**, in the `AuthPluginInit` block around lines 80–87:
- Replace `strconv.ParseInt(retryCount, 10, 64)` + `int(retry)` with `strconv.Atoi(retryCount)` and direct assignment.
- No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
