### PR TITLE
Potential fix for code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/backends/jwt_javascript.go
+++ b/backends/jwt_javascript.go
@@ -31,7 +31,7 @@ func NewJsJWTChecker(authOpts map[string]string, options tokenOptions) (jwtCheck
 	}
 
 	if stackLimit, ok := authOpts["jwt_js_stack_depth_limit"]; ok {
-		limit, err := strconv.ParseInt(stackLimit, 10, 64)
+		limit, err := strconv.ParseInt(stackLimit, 10, strconv.IntSize)
 		if err != nil {
 			log.Errorf("invalid stack depth limit %s, defaulting to %d", stackLimit, js.DefaultStackDepthLimit)
 		} else {


### PR DESCRIPTION
Potential fix for [https://github.com/lhns/mosquitto-go-auth/security/code-scanning/2](https://github.com/lhns/mosquitto-go-auth/security/code-scanning/2)

Use `strconv.ParseInt` with a bit size matching the destination type (`int`) instead of parsing as 64-bit and then narrowing. The safest minimal fix is to change line 34 from `ParseInt(..., 64)` to `ParseInt(..., strconv.IntSize)`. This ensures parsing fails when the value cannot fit in `int` on the current platform, avoiding unsafe conversion behavior while preserving current fallback behavior (log error + keep default).

Change needed in `backends/jwt_javascript.go` in `NewJsJWTChecker`, inside the `jwt_js_stack_depth_limit` block:
- Replace `strconv.ParseInt(stackLimit, 10, 64)` with `strconv.ParseInt(stackLimit, 10, strconv.IntSize)`.
- Keep `checker.stackDepthLimit = int(limit)` as-is (now safe due to parse-time size restriction).
- No new imports or dependencies required (`strconv` is already imported).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
