### PR TITLE
Potential fix for code scanning alert no. 11: Clear-text logging of sensitive information

### DIFF
--- a/hashing/argon2id.go
+++ b/hashing/argon2id.go
@@ -46,12 +46,13 @@ func (h argon2IDHasher) Hash(password string) (string, error) {
 func (h argon2IDHasher) Compare(password string, passwordHash string) bool {
 	hashSplit := strings.Split(passwordHash, "$")
 
-	if hashSplit[1] != "argon2id" {
-		log.Errorf("unknown hash format: %s", hashSplit[1])
-	}
-
 	if len(hashSplit) != 6 {
 		log.Errorf("invalid hash supplied, expected 6 elements, got: %d", len(hashSplit))
+		return false
+	}
+
+	if hashSplit[1] != "argon2id" {
+		log.Errorf("unknown hash format")
 		return false
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/lhns/mosquitto-go-auth/security/code-scanning/11](https://github.com/lhns/mosquitto-go-auth/security/code-scanning/11)

General fix: never log raw or partially parsed credential material (including password hashes, tokens, or any tainted fragments of them). Log only static messages and/or non-sensitive metadata.

Best minimal fix in `hashing/argon2id.go`:
1. Validate `len(hashSplit)` before any indexed access (prevents panic and avoids touching tainted fields early).
2. Replace `log.Errorf("unknown hash format: %s", hashSplit[1])` with a constant message that does not include parsed hash content.
3. Return `false` immediately on unknown format to preserve safe control flow.

This keeps behavior functionally equivalent for authentication (invalid format still fails), improves robustness, and removes sensitive logging.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
