### PR TITLE
Potential fix for code scanning alert no. 13: Clear-text logging of sensitive information

### DIFF
--- a/hashing/pbkdf2.go
+++ b/hashing/pbkdf2.go
@@ -145,7 +145,7 @@ func (h pbkdf2Hasher) Compare(password string, passwordHash string) bool {
 
 		hashedPassword, err = base64.StdEncoding.WithPadding(base64.NoPadding).DecodeString(hashSplit[3])
 	} else {
-		log.Errorf("invalid PBKDF2 hash supplied, unrecognized format \"%s\"", hashSplit[0])
+		log.Errorf("invalid PBKDF2 hash supplied, unrecognized format")
 		return false
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/lhns/mosquitto-go-auth/security/code-scanning/13](https://github.com/lhns/mosquitto-go-auth/security/code-scanning/13)

The best fix is to avoid logging any user-/credential-derived token content. Keep the error log, but make it generic (or include only safe metadata such as token count if needed, though generic is safest and simplest).

**Specific change:**
- **File:** `hashing/pbkdf2.go`
- **Region:** `Compare(...)` else-branch around current line 148.
- Replace:
  - `log.Errorf("invalid PBKDF2 hash supplied, unrecognized format \"%s\"", hashSplit[0])`
- With:
  - `log.Errorf("invalid PBKDF2 hash supplied, unrecognized format")`

No functionality changes (still returns `false`), no new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
