### PR TITLE
Potential fix for code scanning alert no. 12: Clear-text logging of sensitive information

### DIFF
--- a/hashing/pbkdf2.go
+++ b/hashing/pbkdf2.go
@@ -125,7 +125,7 @@ func (h pbkdf2Hasher) Compare(password string, passwordHash string) bool {
 				case "l":
 					keyLen, _ = strconv.Atoi(val)
 				default:
-					log.Errorf("unknown options key (\"%s\")", key)
+					log.Errorf("unknown options key in PBKDF2 hash parameters")
 					return false
 				}
 			}


### PR DESCRIPTION
Potential fix for [https://github.com/lhns/mosquitto-go-auth/security/code-scanning/12](https://github.com/lhns/mosquitto-go-auth/security/code-scanning/12)

To fix this without changing behavior, keep the error path and return value the same, but remove sensitive/untrusted data from logs.

Best fix:
- In `hashing/pbkdf2.go`, in `Compare`, replace:
  - `log.Errorf("unknown options key (\"%s\")", key)`
- With a static message that does not interpolate `key`, e.g.:
  - `log.Errorf("unknown options key in PBKDF2 hash parameters")`

This preserves control flow (`return false`) and operational meaning while preventing clear-text logging of tainted credential-derived input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
