### PR TITLE
test(telemetry): verify metric emission end-to-end

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ without-vcs:
 
 test:
 	cd plugin && make
-	go test ./backends ./cache ./hashing -v -count=1 -buildvcs=false
+	go test ./backends ./cache ./hashing ./telemetry -v -count=1 -buildvcs=false
 	go test . -v -count=1 -buildvcs=false -tags test
 	rm plugin/*.so
 
@@ -39,6 +39,9 @@ test-cache:
 
 test-hashing:
 	go test ./hashing -v -failfast -count=1
+
+test-telemetry:
+	go test ./telemetry -v -failfast -count=1
 
 build-docker-test:
 	docker build -t mosquitto-go-auth.test -f Dockerfile.runtest .

--- a/backends/tracecall_test.go
+++ b/backends/tracecall_test.go
@@ -1,0 +1,81 @@
+package backends
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/iegomez/mosquitto-go-auth/telemetry"
+	"github.com/stretchr/testify/require"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func installTestMeter(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	telemetry.InstallTestMeterProvider(mp)
+	t.Cleanup(func() { telemetry.InstallTestMeterProvider(metricnoop.NewMeterProvider()) })
+	return reader
+}
+
+func backendDuration(t *testing.T, rm metricdata.ResourceMetrics) metricdata.Histogram[float64] {
+	t.Helper()
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == "backend.call.duration" {
+				h, ok := m.Data.(metricdata.Histogram[float64])
+				require.True(t, ok, "backend.call.duration should be a float64 histogram")
+				require.Equal(t, "s", m.Unit)
+				return h
+			}
+		}
+	}
+	t.Fatal("backend.call.duration metric not found")
+	return metricdata.Histogram[float64]{}
+}
+
+func TestTraceBackendCall_GrantedEmitsMetric(t *testing.T) {
+	reader := installTestMeter(t)
+
+	ok, err := traceBackendCall(context.Background(), "files", "get_user",
+		func(ctx context.Context) (bool, error) { return true, nil })
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	h := backendDuration(t, rm)
+	require.Len(t, h.DataPoints, 1)
+	attrs := h.DataPoints[0].Attributes
+	name, _ := attrs.Value("backend.name")
+	op, _ := attrs.Value("backend.op")
+	result, _ := attrs.Value("backend.result")
+	require.Equal(t, "files", name.AsString())
+	require.Equal(t, "get_user", op.AsString())
+	require.Equal(t, "granted", result.AsString())
+}
+
+func TestTraceBackendCall_RejectedAndErrorLabels(t *testing.T) {
+	reader := installTestMeter(t)
+
+	_, _ = traceBackendCall(context.Background(), "files", "check_acl",
+		func(ctx context.Context) (bool, error) { return false, nil })
+	_, _ = traceBackendCall(context.Background(), "files", "check_acl",
+		func(ctx context.Context) (bool, error) { return false, errors.New("boom") })
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	h := backendDuration(t, rm)
+	seen := map[string]bool{}
+	for _, dp := range h.DataPoints {
+		v, _ := dp.Attributes.Value("backend.result")
+		seen[v.AsString()] = true
+	}
+	require.True(t, seen["rejected"], "expected a data point with backend.result=rejected")
+	require.True(t, seen["error"], "expected a data point with backend.result=error")
+}

--- a/go-auth_test.go
+++ b/go-auth_test.go
@@ -147,11 +147,11 @@ func findMetric(t *testing.T, rm metricdata.ResourceMetrics, name string) metric
 	return metricdata.Metrics{}
 }
 
-func resultAttr(m metricdata.Metrics) string {
+func resultAttr(t *testing.T, m metricdata.Metrics) string {
+	t.Helper()
 	h, ok := m.Data.(metricdata.Histogram[float64])
-	if !ok || len(h.DataPoints) == 0 {
-		return ""
-	}
+	require.True(t, ok, "metric %q should be a float64 histogram", m.Name)
+	require.NotEmpty(t, h.DataPoints, "metric %q has no data points", m.Name)
 	v, _ := h.DataPoints[0].Attributes.Value("auth.result")
 	return v.AsString()
 }
@@ -172,7 +172,7 @@ func TestAuthUnpwdCheck_EmitsAuthDuration(t *testing.T) {
 
 	m := findMetric(t, rm, "auth.unpwd_check.duration")
 	require.Equal(t, "s", m.Unit)
-	require.Equal(t, "granted", resultAttr(m))
+	require.Equal(t, "granted", resultAttr(t, m))
 }
 
 func TestAuthUnpwdCheck_ErrorResultLabel(t *testing.T) {
@@ -188,7 +188,7 @@ func TestAuthUnpwdCheck_ErrorResultLabel(t *testing.T) {
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(context.Background(), &rm))
 
-	require.Equal(t, "error", resultAttr(findMetric(t, rm, "auth.unpwd_check.duration")))
+	require.Equal(t, "error", resultAttr(t, findMetric(t, rm, "auth.unpwd_check.duration")))
 }
 
 func TestAuthAclCheck_EmitsACLDuration(t *testing.T) {
@@ -206,5 +206,5 @@ func TestAuthAclCheck_EmitsACLDuration(t *testing.T) {
 
 	m := findMetric(t, rm, "auth.acl_check.duration")
 	require.Equal(t, "s", m.Unit)
-	require.Equal(t, "rejected", resultAttr(m))
+	require.Equal(t, "rejected", resultAttr(t, m))
 }

--- a/go-auth_test.go
+++ b/go-auth_test.go
@@ -4,6 +4,12 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"github.com/iegomez/mosquitto-go-auth/telemetry"
+	"github.com/stretchr/testify/require"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 type mockBackends struct {
@@ -115,4 +121,90 @@ func Test_authUnpwdCheck(t *testing.T) {
 			}
 		})
 	}
+}
+
+// installTestMeter wires package telemetry instruments to a ManualReader and
+// returns the reader. Restores no-op instruments on test cleanup.
+func installTestMeter(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	telemetry.InstallTestMeterProvider(mp)
+	t.Cleanup(func() { telemetry.InstallTestMeterProvider(metricnoop.NewMeterProvider()) })
+	return reader
+}
+
+func findMetric(t *testing.T, rm metricdata.ResourceMetrics, name string) metricdata.Metrics {
+	t.Helper()
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				return m
+			}
+		}
+	}
+	t.Fatalf("metric %q not found", name)
+	return metricdata.Metrics{}
+}
+
+func resultAttr(m metricdata.Metrics) string {
+	h, ok := m.Data.(metricdata.Histogram[float64])
+	if !ok || len(h.DataPoints) == 0 {
+		return ""
+	}
+	v, _ := h.DataPoints[0].Attributes.Value("auth.result")
+	return v.AsString()
+}
+
+func TestAuthUnpwdCheck_EmitsAuthDuration(t *testing.T) {
+	reader := installTestMeter(t)
+
+	authPlugin = AuthPlugin{
+		backends: &mockBackends{authResult: true},
+		ctx:      context.Background(),
+	}
+	ok, err := authUnpwdCheck("user", "pass", "client")
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	m := findMetric(t, rm, "auth.unpwd_check.duration")
+	require.Equal(t, "s", m.Unit)
+	require.Equal(t, "granted", resultAttr(m))
+}
+
+func TestAuthUnpwdCheck_ErrorResultLabel(t *testing.T) {
+	reader := installTestMeter(t)
+
+	authPlugin = AuthPlugin{
+		backends: &mockBackends{authErr: errBackendFailure},
+		ctx:      context.Background(),
+	}
+	_, err := authUnpwdCheck("user", "pass", "client")
+	require.Error(t, err)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	require.Equal(t, "error", resultAttr(findMetric(t, rm, "auth.unpwd_check.duration")))
+}
+
+func TestAuthAclCheck_EmitsACLDuration(t *testing.T) {
+	reader := installTestMeter(t)
+
+	authPlugin = AuthPlugin{
+		backends: &mockBackends{},
+		ctx:      context.Background(),
+	}
+	_, err := authAclCheck("client", "user", "topic", 1)
+	require.NoError(t, err)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	m := findMetric(t, rm, "auth.acl_check.duration")
+	require.Equal(t, "s", m.Unit)
+	require.Equal(t, "rejected", resultAttr(m))
 }

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -155,6 +155,13 @@ func buildResource(ctx context.Context) (*resource.Resource, error) {
 	)
 }
 
+// InstallTestMeterProvider rebinds the package's metric instruments to the
+// given MeterProvider. Intended for tests only — production code should call
+// Init to configure telemetry from OTEL_* environment variables.
+func InstallTestMeterProvider(mp metric.MeterProvider) {
+	bindInstruments(mp.Meter(meterName))
+}
+
 func bindInstruments(m metric.Meter) {
 	AuthDuration, _ = m.Float64Histogram(
 		"auth.unpwd_check.duration",

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -65,27 +65,81 @@ func TestInstrumentsRecordToReader(t *testing.T) {
 		attribute.String("backend.result", "granted"),
 	))
 	CacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("auth.kind", "unpwd")))
-	CacheMisses.Add(ctx, 1, metric.WithAttributes(attribute.String("auth.kind", "acl")))
+	CacheMisses.Add(ctx, 2, metric.WithAttributes(attribute.String("auth.kind", "acl")))
 
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(ctx, &rm))
 
-	want := map[string]string{
-		"auth.unpwd_check.duration": "s",
-		"auth.acl_check.duration":   "s",
-		"backend.call.duration":     "s",
-		"auth.cache.hits":           "{hit}",
-		"auth.cache.misses":         "{miss}",
-	}
-	got := map[string]string{}
+	metrics := map[string]metricdata.Metrics{}
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {
-			got[m.Name] = m.Unit
+			metrics[m.Name] = m
 		}
 	}
-	for name, unit := range want {
-		require.Equal(t, unit, got[name], "metric %q missing or wrong unit", name)
+
+	histCases := []struct {
+		name, attrKey, attrVal string
+	}{
+		{"auth.unpwd_check.duration", "auth.result", "granted"},
+		{"auth.acl_check.duration", "auth.result", "rejected"},
+		{"backend.call.duration", "backend.result", "granted"},
 	}
+	for _, tc := range histCases {
+		m, ok := metrics[tc.name]
+		require.True(t, ok, "histogram %q missing", tc.name)
+		require.Equal(t, "s", m.Unit)
+		h, ok := m.Data.(metricdata.Histogram[float64])
+		require.True(t, ok, "%q should be a float64 histogram", tc.name)
+		require.NotEmpty(t, h.DataPoints, "%q has no data points", tc.name)
+		v, _ := h.DataPoints[0].Attributes.Value(attribute.Key(tc.attrKey))
+		require.Equal(t, tc.attrVal, v.AsString(), "%q missing %s=%s", tc.name, tc.attrKey, tc.attrVal)
+	}
+
+	counterCases := []struct {
+		name, unit, kind string
+		wantVal          int64
+	}{
+		{"auth.cache.hits", "{hit}", "unpwd", 1},
+		{"auth.cache.misses", "{miss}", "acl", 2},
+	}
+	for _, tc := range counterCases {
+		m, ok := metrics[tc.name]
+		require.True(t, ok, "counter %q missing", tc.name)
+		require.Equal(t, tc.unit, m.Unit)
+		s, ok := m.Data.(metricdata.Sum[int64])
+		require.True(t, ok, "%q should be an int64 sum", tc.name)
+		require.NotEmpty(t, s.DataPoints, "%q has no data points", tc.name)
+		require.Equal(t, tc.wantVal, s.DataPoints[0].Value)
+		v, _ := s.DataPoints[0].Attributes.Value("auth.kind")
+		require.Equal(t, tc.kind, v.AsString())
+	}
+}
+
+func TestInit_NoEnv(t *testing.T) {
+	for _, k := range []string{
+		"OTEL_SDK_DISABLED",
+		"OTEL_EXPORTER_OTLP_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+		"OTEL_SERVICE_NAME",
+	} {
+		t.Setenv(k, "")
+	}
+
+	shutdown, err := Init(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, shutdown)
+	require.False(t, Active())
+
+	// Instruments must stay safe to call when telemetry never activated.
+	require.NotPanics(t, func() {
+		AuthDuration.Record(context.Background(), 0.001,
+			metric.WithAttributes(attribute.String("auth.result", "granted")))
+		CacheHits.Add(context.Background(), 1,
+			metric.WithAttributes(attribute.String("auth.kind", "unpwd")))
+	})
+
+	require.NoError(t, shutdown(context.Background()))
 }
 
 func TestLogrusHook_AddsTraceAndSpanID(t *testing.T) {

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -1,0 +1,111 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestShouldActivate(t *testing.T) {
+	// Clear everything we care about first; t.Setenv restores on cleanup.
+	for _, k := range []string{
+		"OTEL_SDK_DISABLED",
+		"OTEL_EXPORTER_OTLP_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+		"OTEL_SERVICE_NAME",
+	} {
+		t.Setenv(k, "")
+	}
+
+	cases := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{"no env", nil, false},
+		{"service name set", map[string]string{"OTEL_SERVICE_NAME": "x"}, true},
+		{"otlp endpoint set", map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "http://collector:4317"}, true},
+		{"traces endpoint set", map[string]string{"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://collector:4317"}, true},
+		{"metrics endpoint set", map[string]string{"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://collector:4317"}, true},
+		{"sdk disabled overrides service name", map[string]string{"OTEL_SDK_DISABLED": "true", "OTEL_SERVICE_NAME": "x"}, false},
+		{"sdk disabled false is not itself a trigger", map[string]string{"OTEL_SDK_DISABLED": "false"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			require.Equal(t, tc.want, shouldActivate())
+		})
+	}
+}
+
+func TestInstrumentsRecordToReader(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	bindInstruments(mp.Meter(meterName))
+	t.Cleanup(func() { bindInstruments(metricnoop.NewMeterProvider().Meter(meterName)) })
+
+	ctx := context.Background()
+	AuthDuration.Record(ctx, 0.001, metric.WithAttributes(attribute.String("auth.result", "granted")))
+	ACLDuration.Record(ctx, 0.002, metric.WithAttributes(attribute.String("auth.result", "rejected")))
+	BackendDuration.Record(ctx, 0.003, metric.WithAttributes(
+		attribute.String("backend.name", "files"),
+		attribute.String("backend.op", "get_user"),
+		attribute.String("backend.result", "granted"),
+	))
+	CacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("auth.kind", "unpwd")))
+	CacheMisses.Add(ctx, 1, metric.WithAttributes(attribute.String("auth.kind", "acl")))
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &rm))
+
+	want := map[string]string{
+		"auth.unpwd_check.duration": "s",
+		"auth.acl_check.duration":   "s",
+		"backend.call.duration":     "s",
+		"auth.cache.hits":           "{hit}",
+		"auth.cache.misses":         "{miss}",
+	}
+	got := map[string]string{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			got[m.Name] = m.Unit
+		}
+	}
+	for name, unit := range want {
+		require.Equal(t, unit, got[name], "metric %q missing or wrong unit", name)
+	}
+}
+
+func TestLogrusHook_AddsTraceAndSpanID(t *testing.T) {
+	tp := sdktrace.NewTracerProvider()
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	ctx, span := tp.Tracer("test").Start(context.Background(), "op")
+	defer span.End()
+
+	entry := &log.Entry{Context: ctx}
+	require.NoError(t, (&LogrusHook{}).Fire(entry))
+
+	sc := trace.SpanContextFromContext(ctx)
+	require.Equal(t, sc.TraceID().String(), entry.Data["trace_id"])
+	require.Equal(t, sc.SpanID().String(), entry.Data["span_id"])
+}
+
+func TestLogrusHook_NoSpan_NoFields(t *testing.T) {
+	entry := &log.Entry{Context: context.Background()}
+	require.NoError(t, (&LogrusHook{}).Fire(entry))
+	require.Nil(t, entry.Data["trace_id"])
+	require.Nil(t, entry.Data["span_id"])
+}


### PR DESCRIPTION
Covers the five instruments exposed in the telemetry package and the two integration points that record through them:

- telemetry/telemetry_test.go — shouldActivate env matrix, direct recording through a ManualReader, LogrusHook trace/span id injection
- go-auth_test.go — authUnpwdCheck and authAclCheck emit auth.unpwd_check.duration / auth.acl_check.duration with the expected auth.result label (granted / rejected / error)
- backends/tracecall_test.go — traceBackendCall emits backend.call.duration with backend.name / backend.op / backend.result

Tests wire a sdkmetric.ManualReader via the new
telemetry.InstallTestMeterProvider helper and assert metric names, units, and attribute labels match the current OTel semconv alignment.