### PR TITLE
fix: prevent HTTP connection/goroutine leaks and cache goroutine leak on shutdown

### DIFF
--- a/.github/workflows/build_and_push_docker_images.yml
+++ b/.github/workflows/build_and_push_docker_images.yml
@@ -21,16 +21,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      
+
+      - name: Set lowercase owner
+        run: echo "OWNER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Set Mosquitto version
         run: sed -i 's/ARG MOSQUITTO_VERSION=${{ env.DOCKERFILE_MOSQUITTO_VERSION }}/ARG MOSQUITTO_VERSION=${{ env.MOSQUITTO_VERSION_1 }}/' Dockerfile
-      
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-        
+
       - name: Login to GitHub Container Registry
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -40,7 +43,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Build and push on release
         if: github.event_name == 'release' && github.event.action == 'published'
         uses: docker/build-push-action@v7
@@ -49,9 +52,9 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/${{ env.DOCKERHUB_REPO }}:${{ github.event.release.tag_name }}${{ format('{0}{1}', env.MOSQUITTO_VERSION_SUFFIX, env.MOSQUITTO_VERSION_1) }}
-            ghcr.io/${{ github.repository_owner }}/${{ env.DOCKERHUB_REPO }}:latest${{ format('{0}{1}', env.MOSQUITTO_VERSION_SUFFIX, env.MOSQUITTO_VERSION_1) }}
-      
+            ghcr.io/${{ env.OWNER }}/${{ env.DOCKERHUB_REPO }}:${{ github.event.release.tag_name }}${{ format('{0}{1}', env.MOSQUITTO_VERSION_SUFFIX, env.MOSQUITTO_VERSION_1) }}
+            ghcr.io/${{ env.OWNER }}/${{ env.DOCKERHUB_REPO }}:latest${{ format('{0}{1}', env.MOSQUITTO_VERSION_SUFFIX, env.MOSQUITTO_VERSION_1) }}
+
       - name: Build and push on push
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: docker/build-push-action@v7
@@ -59,8 +62,8 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/${{ env.DOCKERHUB_REPO }}:master${{ format('{0}{1}', env.MOSQUITTO_VERSION_SUFFIX, env.MOSQUITTO_VERSION_1) }}
-      
+          tags: ghcr.io/${{ env.OWNER }}/${{ env.DOCKERHUB_REPO }}:master${{ format('{0}{1}', env.MOSQUITTO_VERSION_SUFFIX, env.MOSQUITTO_VERSION_1) }}
+
       - name: Build on push
         if: github.event_name == 'push' && github.ref != 'refs/heads/master'
         uses: docker/build-push-action@v7
@@ -77,16 +80,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      
+
+      - name: Set lowercase owner
+        run: echo "OWNER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Set Mosquitto version
         run: sed -i 's/ARG MOSQUITTO_VERSION=${{ env.DOCKERFILE_MOSQUITTO_VERSION }}/ARG MOSQUITTO_VERSION=${{ env.MOSQUITTO_VERSION_2 }}/' Dockerfile
-      
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-      
+
       - name: Login to GitHub Container Registry
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -96,7 +102,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Build and push on release
         if: github.event_name == 'release' && github.event.action == 'published'
         uses: docker/build-push-action@v7
@@ -105,11 +111,11 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/${{ env.DOCKERHUB_REPO }}:${{ github.event.release.tag_name }}${{ format('{0}{1}', env.MOSQUITTO_VERSION_SUFFIX, env.MOSQUITTO_VERSION_2) }}
-            ghcr.io/${{ github.repository_owner }}/${{ env.DOCKERHUB_REPO }}:${{ github.event.release.tag_name }}
-            ghcr.io/${{ github.repository_owner }}/${{ env.DOCKERHUB_REPO }}:latest${{ format('{0}{1}', env.MOSQUITTO_VERSION_SUFFIX, env.MOSQUITTO_VERSION_2) }}
-            ghcr.io/${{ github.repository_owner }}/${{ env.DOCKERHUB_REPO }}:latest
-      
+            ghcr.io/${{ env.OWNER }}/${{ env.DOCKERHUB_REPO }}:${{ github.event.release.tag_name }}${{ format('{0}{1}', env.MOSQUITTO_VERSION_SUFFIX, env.MOSQUITTO_VERSION_2) }}
+            ghcr.io/${{ env.OWNER }}/${{ env.DOCKERHUB_REPO }}:${{ github.event.release.tag_name }}
+            ghcr.io/${{ env.OWNER }}/${{ env.DOCKERHUB_REPO }}:latest${{ format('{0}{1}', env.MOSQUITTO_VERSION_SUFFIX, env.MOSQUITTO_VERSION_2) }}
+            ghcr.io/${{ env.OWNER }}/${{ env.DOCKERHUB_REPO }}:latest
+
       - name: Build and push on push
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: docker/build-push-action@v7
@@ -118,9 +124,9 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/${{ env.DOCKERHUB_REPO }}:master${{ format('{0}{1}', env.MOSQUITTO_VERSION_SUFFIX, env.MOSQUITTO_VERSION_2) }}
-            ghcr.io/${{ github.repository_owner }}/${{ env.DOCKERHUB_REPO }}:master
-      
+            ghcr.io/${{ env.OWNER }}/${{ env.DOCKERHUB_REPO }}:master${{ format('{0}{1}', env.MOSQUITTO_VERSION_SUFFIX, env.MOSQUITTO_VERSION_2) }}
+            ghcr.io/${{ env.OWNER }}/${{ env.DOCKERHUB_REPO }}:master
+
       - name: Build on push
         if: github.event_name == 'push' && github.ref != 'refs/heads/master'
         uses: docker/build-push-action@v7

--- a/backends/http.go
+++ b/backends/http.go
@@ -151,6 +151,8 @@ func NewHTTP(authOpts map[string]string, logLevel log.Level, version string) (HT
 	if !http.VerifyPeer {
 		tr := &h.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			MaxIdleConns:    100,
+			IdleConnTimeout: 90 * time.Second,
 		}
 		http.Client.Transport = tr
 	}

--- a/backends/http.go
+++ b/backends/http.go
@@ -284,14 +284,14 @@ func (o HTTP) httpRequest(uri, username string, dataMap map[string]interface{}, 
 		return false, err
 	}
 
+	defer resp.Body.Close()
+
 	body, err := ioutil.ReadAll(resp.Body)
 
 	if err != nil {
 		log.Errorf("read error: %s", err)
 		return false, err
 	}
-
-	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		log.Infof("error code: %d", resp.StatusCode)

--- a/backends/jwt_remote.go
+++ b/backends/jwt_remote.go
@@ -322,14 +322,14 @@ func (o *remoteJWTChecker) jwtRequest(uri, token string, dataMap map[string]inte
 		return false, err
 	}
 
+	defer resp.Body.Close()
+
 	body, err := ioutil.ReadAll(resp.Body)
 
 	if err != nil {
 		log.Errorf("read error: %s", err)
 		return false, err
 	}
-
-	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		log.Infof("error code: %d", resp.StatusCode)

--- a/backends/jwt_remote.go
+++ b/backends/jwt_remote.go
@@ -166,6 +166,8 @@ func NewRemoteJWTChecker(authOpts map[string]string, options tokenOptions, versi
 	if !checker.verifyPeer {
 		tr := &h.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			MaxIdleConns:    100,
+			IdleConnTimeout: 90 * time.Second,
 		}
 		checker.client.Transport = tr
 	}
@@ -302,15 +304,17 @@ func (o *remoteJWTChecker) jwtRequest(uri, token string, dataMap map[string]inte
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("User-Agent", o.userAgent)
 	default:
-		req, err = h.NewRequest(o.httpMethod, fullURI, strings.NewReader(urlValues.Encode()))
-		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-		req.Header.Set("Content-Length", strconv.Itoa(len(urlValues.Encode())))
-		req.Header.Set("User-Agent", o.userAgent)
+		formEncoded := urlValues.Encode()
+		req, err = h.NewRequest(o.httpMethod, fullURI, strings.NewReader(formEncoded))
 
 		if err != nil {
 			log.Errorf("req error: %s", err)
 			return false, err
 		}
+
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Content-Length", strconv.Itoa(len(formEncoded)))
+		req.Header.Set("User-Agent", o.userAgent)
 	}
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -175,7 +175,7 @@ func (s *redisStore) Connect(ctx context.Context, reset bool) bool {
 }
 
 func (s *goStore) Close() {
-	//TODO: support serializing cache for re hydration.
+	s.client.Stop()
 }
 
 func (s *redisStore) Close() {


### PR DESCRIPTION
## Summary
- Close the HTTP response body even when reading it fails, in both `backends/http.go` and `backends/jwt_remote.go` (previously the `defer resp.Body.Close()` ran after the error-path early return).
- Set `MaxIdleConns`/`IdleConnTimeout` on the custom `http.Transport` used when `verify_peer` is disabled, matching `http.DefaultTransport` (100 / 90s). Without these, idle keep-alive connections and their `readLoop`/`writeLoop` goroutines accumulate indefinitely — this matters especially with dynamic JWT issuer hosts.
- Fix a nil-pointer risk in `jwt_remote.go`'s form-params request path: the error from `http.NewRequest` was checked *after* the header fields were set on a possibly-nil `req`. Also avoid encoding the form values twice.
- Call `s.client.Stop()` in `goStore.Close()` (`cache/cache.go`) to stop the `ttlcache` background cleanup goroutine, which previously leaked on plugin shutdown/reload.
- CI: lowercase the repository owner in the Docker build workflow before using it in image tags, since Docker tags must be lowercase (harmless for this repo but avoids breaking on forks with mixed-case owners).