### PR TITLE
Fix nil-pointer panic in goStore.checkRecord under concurrent load

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -208,7 +208,7 @@ func (s *goStore) checkRecord(ctx context.Context, record string, expirationTime
 		return false, false
 	}
 
-	return present, item.Value()
+	return true, item.Value()
 }
 
 // CheckAuthRecord checks if the username/password pair is present in the cache. Return if it's present and, if so, if it was granted privileges

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -196,16 +196,16 @@ func (s *goStore) CheckACLRecord(ctx context.Context, username, topic, clientid 
 
 func (s *goStore) checkRecord(ctx context.Context, record string, expirationTime time.Duration) (bool, bool) {
 	var item *ttlcache.Item[string, bool]
-	present := s.client.Has(record)
-
-	if !present {
-		return false, false
-	}
 
 	if !s.refreshExpiration {
 		item = s.client.Get(record, ttlcache.WithDisableTouchOnHit[string, bool]())
 	} else {
 		item = s.client.Get(record)
+	}
+
+	// Get returns nil when the key is absent or expired
+	if item == nil {
+		return false, false
 	}
 
 	return present, item.Value()


### PR DESCRIPTION
The check-then-act Has()/Get() split raced: Has() could report a record present, the entry expire, and Get() then return nil, panicking on item.Value() under concurrent ACL checks — which crashed the in-process mosquitto broker. Drop the redundant Has() and nil-check Get(), which already returns nil for absent or expired keys.

Cherry-picked from: https://github.com/somo-ai/mosquitto-go-auth/commit/fa3fa99d36d172ad928ad74c45030103275e3190